### PR TITLE
Improve nginx sendfile handling

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -73,6 +73,9 @@ http {
       proxy_set_header Host $http_host;
       proxy_redirect off;
 
+      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+      proxy_set_header X-Accel-Mapping $upstream_http_x_media_path/=/private_media/;
+
       proxy_pass http://backend;
     }
   }


### PR DESCRIPTION
I noticed in the nginx logs the message `X-Accel-Mapping header missing` - this PR adds that header so that nginx handles the send_file from rack.

I'm not using docker in my deployment of black_candy, but I added a very similar config, so please confirm it's working correctly in a docker deploy before merging.

Also - it looks like that error message is still showing in the CI logs, I'm not sure if the CI uses the nginx config from `config/nginx/nginx.conf`?