### PR TITLE
Use GlobalID for all Jobs

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -21,7 +21,7 @@ class AlbumsController < ApplicationController
 
   def show
     @songs = @album.songs.includes(:artist)
-    AttachAlbumImageFromDiscogsJob.perform_later(@album.id) if @album.need_attach_from_discogs?
+    AttachAlbumImageFromDiscogsJob.perform_later(@album) if @album.need_attach_from_discogs?
   end
 
   def edit

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -17,7 +17,7 @@ class ArtistsController < ApplicationController
     @albums = @artist.albums.load_async
     @appears_on_albums = @artist.appears_on_albums.load_async
 
-    AttachArtistImageFromDiscogsJob.perform_later(@artist.id) if @artist.need_attach_from_discogs?
+    AttachArtistImageFromDiscogsJob.perform_later(@artist) if @artist.need_attach_from_discogs?
   end
 
   def edit

--- a/app/jobs/attach_album_image_from_discogs_job.rb
+++ b/app/jobs/attach_album_image_from_discogs_job.rb
@@ -3,8 +3,7 @@
 class AttachAlbumImageFromDiscogsJob < ApplicationJob
   queue_as :default
 
-  def perform(album_id)
-    album = Album.find_by(id: album_id)
+  def perform(album)
     image_url = DiscogsApi.album_image(album)
 
     return if image_url.blank?

--- a/app/jobs/attach_album_image_from_file_job.rb
+++ b/app/jobs/attach_album_image_from_file_job.rb
@@ -3,8 +3,7 @@
 class AttachAlbumImageFromFileJob < ApplicationJob
   queue_as :default
 
-  def perform(album_id, file_path)
-    album = Album.find_by(id: album_id)
+  def perform(album, file_path)
     file_image = MediaFile.image(file_path)
 
     return unless album && file_image.present?

--- a/app/jobs/attach_artist_image_from_discogs_job.rb
+++ b/app/jobs/attach_artist_image_from_discogs_job.rb
@@ -3,8 +3,7 @@
 class AttachArtistImageFromDiscogsJob < ApplicationJob
   queue_as :default
 
-  def perform(artist_id)
-    artist = Artist.find_by(id: artist_id)
+  def perform(artist)
     image_url = DiscogsApi.artist_image(artist)
 
     return if image_url.blank?

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -18,7 +18,7 @@ class Media
     end
 
     # Attach image from file to the album.
-    AttachAlbumImageFromFileJob.perform_later(album.id, file_info[:file_path]) unless album.has_image?
+    AttachAlbumImageFromFileJob.perform_later(album, file_info[:file_path]) unless album.has_image?
 
     Song.find_or_create_by(md5_hash: file_info[:md5_hash]) do |item|
       item.attributes = song_info.merge(album: album, artist: artist)

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -35,7 +35,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     Setting.update(discogs_token: "fake_token")
     album = albums(:album1)
     mock = MiniTest::Mock.new
-    mock.expect(:call, true, [album.id])
+    mock.expect(:call, true, [album])
 
     assert_not album.has_image?
     assert_not album.is_unknown?

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -35,7 +35,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     Setting.update(discogs_token: "fake_token")
     artist = artists(:artist1)
     mock = MiniTest::Mock.new
-    mock.expect(:call, true, [artist.id])
+    mock.expect(:call, true, [artist])
 
     assert_not artist.has_image?
     assert_not artist.is_unknown?

--- a/test/jobs/attach_album_image_from_discogs_job_test.rb
+++ b/test/jobs/attach_album_image_from_discogs_job_test.rb
@@ -16,7 +16,7 @@ class AttachAlbumImageFromDiscogsJobTest < ActiveJob::TestCase
     DiscogsApi.stub(:album_image, "http://example.com/cover.jpg") do
       assert_not album.has_image?
 
-      AttachAlbumImageFromDiscogsJob.perform_now(album.id)
+      AttachAlbumImageFromDiscogsJob.perform_now(album)
       assert album.reload.has_image?
     end
   end

--- a/test/jobs/attach_album_image_from_file_job_test.rb
+++ b/test/jobs/attach_album_image_from_file_job_test.rb
@@ -13,7 +13,7 @@ class AttachAlbumImageFromFileJobTest < ActiveJob::TestCase
     MediaFile.stub(:image, data: file_fixture("cover_image.jpg").read.force_encoding("BINARY"), format: "jpeg") do
       assert_not album.has_image?
 
-      AttachAlbumImageFromFileJob.perform_now(album.id, file_fixture("cover_image.jpg"))
+      AttachAlbumImageFromFileJob.perform_now(album, file_fixture("cover_image.jpg"))
       assert album.reload.has_image?
     end
   end

--- a/test/jobs/attach_artist_image_from_discogs_job_test.rb
+++ b/test/jobs/attach_artist_image_from_discogs_job_test.rb
@@ -16,7 +16,7 @@ class AttachArtistImageFromDiscogsJobTest < ActiveJob::TestCase
     DiscogsApi.stub(:artist_image, "http://example.com/cover.jpg") do
       assert_not artist.has_image?
 
-      AttachArtistImageFromDiscogsJob.perform_now(artist.id)
+      AttachArtistImageFromDiscogsJob.perform_now(artist)
       assert artist.reload.has_image?
     end
   end


### PR DESCRIPTION
Rails provides GlobalID serialization for all activerecord objects, so there's no need to pass just the id and then find the record inside the job.