### PR TITLE
Search appearance

### DIFF
--- a/app/assets/stylesheets/components/input.css
+++ b/app/assets/stylesheets/components/input.css
@@ -21,6 +21,10 @@ input.c-input {
   flex-grow: 1;
 }
 
+.c-input-group input:focus {
+  outline: none;
+}
+
 .c-input-group__icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
In webkit based browsers, an outline is applied to the search field when focused that separates it and makes it larger than the search group it's a part of, ruining the effect that it's one field:

<img width="517" alt="Black Candy 2022-02-20 13-53-41" src="https://user-images.githubusercontent.com/27690/154865983-16c7a35b-0dcc-4cad-a247-cd7941628d4d.png">

I applied an `outline: none;` style to remove the outline:

<img width="472" alt="Black Candy 2022-02-20 13-57-42" src="https://user-images.githubusercontent.com/27690/154866114-a2384de9-236c-4300-9310-2edaf35311f2.png">

A more sophisticated solution might make the icon display inside the field, but I think this is an improvement.
