### PR TITLE
Fixes #123 - Avoid Unpermitted parameters on Playlists::SongsController

### DIFF
--- a/app/controllers/playlists/songs_controller.rb
+++ b/app/controllers/playlists/songs_controller.rb
@@ -29,7 +29,7 @@ class Playlists::SongsController < ApplicationController
   end
 
   def destroy
-    if playlists_songs_params[:clear_all]
+    if params[:clear_all]
       @playlist.songs.clear
     else
       @playlist.songs.destroy(@song)
@@ -41,8 +41,8 @@ class Playlists::SongsController < ApplicationController
   end
 
   def update
-    from_position = Integer(playlists_songs_params[:from_position])
-    to_position = Integer(playlists_songs_params[:to_position])
+    from_position = Integer(params[:from_position])
+    to_position = Integer(params[:to_position])
 
     playlists_song = @playlist.playlists_songs.find_by(position: from_position)
     playlists_song.update(position: to_position)
@@ -55,14 +55,10 @@ class Playlists::SongsController < ApplicationController
   end
 
   def find_song
-    @song = Song.find(playlists_songs_params[:song_id]) unless playlists_songs_params[:clear_all]
+    @song = Song.find(params[:song_id]) unless params[:clear_all]
   end
 
   def find_all_song_ids
     @song_ids = @playlist.song_ids
-  end
-
-  def playlists_songs_params
-    params.permit(:from_position, :to_position, :clear_all, :song_id)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,8 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   config.active_job.queue_adapter = :sidekiq
 
   config.after_initialize do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,5 +48,7 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 end


### PR DESCRIPTION
Calling `permit` on the base params makes other params that are submitted invalid - and there are others, such as playlist_id and authenticity_token.

Because no params are being mass-assigned, there's no benefit to calling `permit` anyway, so remove `playlist_songs_params`

Added a config to dev and test to raise when unpermitted params are passed to surface errors like this.