### PR TITLE
Lookup album image from Discogs if possible if attaching from file fails

### DIFF
--- a/app/jobs/attach_album_image_from_file_job.rb
+++ b/app/jobs/attach_album_image_from_file_job.rb
@@ -6,9 +6,11 @@ class AttachAlbumImageFromFileJob < ApplicationJob
   def perform(album, file_path)
     file_image = MediaFile.image(file_path)
 
-    return unless album && file_image.present?
-
-    album.image = CarrierWaveStringIO.new("cover.#{file_image[:format]}", file_image[:data])
-    album.save
+    if album && file_image.present?
+      album.image = CarrierWaveStringIO.new("cover.#{file_image[:format]}", file_image[:data])
+      album.save
+    elsif album.need_attach_from_discogs?
+      AttachAlbumImageFromDiscogsJob.perform_later(album)
+    end
   end
 end

--- a/test/jobs/attach_album_image_from_file_job_test.rb
+++ b/test/jobs/attach_album_image_from_file_job_test.rb
@@ -7,7 +7,7 @@ class AttachAlbumImageFromFileJobTest < ActiveJob::TestCase
     albums(:album1).image.remove!
   end
 
-  test "should attach image to album" do
+  test "should attach image to album when available" do
     album = albums(:album1)
 
     MediaFile.stub(:image, data: file_fixture("cover_image.jpg").read.force_encoding("BINARY"), format: "jpeg") do
@@ -15,6 +15,19 @@ class AttachAlbumImageFromFileJobTest < ActiveJob::TestCase
 
       AttachAlbumImageFromFileJob.perform_now(album, file_fixture("cover_image.jpg"))
       assert album.reload.has_image?
+
+      assert_no_enqueued_jobs
+    end
+  end
+
+  test "should queue a job to lookup the image from discogs when possible and not found" do
+    album = albums(:album1)
+    assert_not album.has_image?
+
+    album.stub(:need_attach_from_discogs?, true) do
+      assert_enqueued_with(job: AttachAlbumImageFromDiscogsJob, args: [album], queue: "default") do
+        AttachAlbumImageFromFileJob.perform_now(album, file_fixture("artist2_album3.oga"))
+      end
     end
   end
 end


### PR DESCRIPTION
When syncing the media library, album art is looked up from the file, and if not found, is left blank even when the art can be found on discogs.

This change automatically queues a job to attempt to attach the album art from discogs if not found when attaching from the file - and discogs lookup is available.