### PR TITLE
Fix Docker Compose file for v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,12 @@ services:
     volumes:
       - production_redis_data:/data
   worker:
-    container_name: 'blackcandy_worker'
     <<: *app_base
+    container_name: 'blackcandy_worker'
     command: bundle exec sidekiq
   web:
-    container_name: 'blackcandy_web'
     <<: *app_base
+    container_name: 'blackcandy_web'
     depends_on:
       - app
       - worker
@@ -43,8 +43,8 @@ services:
       - 80:80
     command: nginx -g 'pid /tmp/nginx.pid; daemon off;'
   listener:
-    container_name: 'blackcandy_listener'
     <<: *app_base
+    container_name: 'blackcandy_listener'
     command: bundle exec rails listen_media_changes
 volumes:
   production_db_data:


### PR DESCRIPTION
This pull request arranges order of `app_base` inheritance and `container_name` in `docker-compose.yml`, which fixes Docker container name conflicts (`/blackcandy_app`) when using Docker Compose v2.
(Perhaps it is because the container name has been overwritten by inheritance.)

fix #180 