### PR TITLE
Make titles available on all pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,11 +52,11 @@ module ApplicationHelper
     params[:controller].in?(Array(controller)) || (path.is_a?(Regexp) ? (path =~ request.path) : (path == request.path))
   end
 
-  def page_title_tag(title, show_on_native: true)
+  def page_title_tag(title)
     title_suffix = " - #{t(:app_name)}"
     title = "#{title}#{title_suffix unless turbo_native?}"
 
-    content_for(:title, title) unless turbo_native? && !show_on_native
+    content_for(:title, title)
   end
 
   def current_url

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title_tag @album.title, show_on_native: false %>
+<% page_title_tag @album.title %>
 
 <div class='o-container o-container--narrow' data-controller='playlist-songs'>
   <div class='c-card c-card--horizontal c-card--center@narrow u-my-large'>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title_tag @artist.title, show_on_native: false %>
+<% page_title_tag @artist.title %>
 
 <div class='o-container o-container--wide'>
   <div class='c-card c-card--horizontal c-card--center@narrow u-my-large'>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>
-    <title><%= content_for?(:title) ? yield(:title) : (t(:app_name) unless turbo_native?) %></title>
+    <title><%= content_for?(:title) ? yield(:title) : t(:app_name) %></title>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "link_icon.png", type: "image/png" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
Because on Turbo Android, if a page doesn't have a title, it will set the current page URL as the view title. It seems to be a default behavior on android web view. So to avoid this, I need to enable title on all page no matter the page is on native web view or not.