### PR TITLE
Remove queue name prefix in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,8 +67,6 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = BlackCandy::Config.redis_sidekiq_url.present? ? :sidekiq : :litejob
 
-  config.active_job.queue_name_prefix = "black_candy_production"
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
The queue name prefix will cause litejob can not to process background jobs.