### PR TITLE
Fix style issue of player progress bar in Safari

### DIFF
--- a/app/assets/stylesheets/components/_player.scss
+++ b/app/assets/stylesheets/components/_player.scss
@@ -47,6 +47,7 @@
 }
 
 .c-player__progress progress {
+  appearance: none;
   height: 2px;
   border: 0 none;
   background: var(--player-progress-bg-color);


### PR DESCRIPTION
In order to let `::-webkit-progress-value` take effect, appearance needs to be set to none on the <progress> element.